### PR TITLE
Sync node version requirements with react-router

### DIFF
--- a/.yarn/versions/818b1fb6.yml
+++ b/.yarn/versions/818b1fb6.yml
@@ -1,0 +1,2 @@
+releases:
+  react-router-typesafe-routes: patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Add [CONTRIBUTING.md](./CONTRIBUTING.md)
 
+### Fixed
+
+-   Sync node version requirements with react-router.
+
 ## [0.5.0] - 2022-09-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+-   Add [CONTRIBUTING.md](./CONTRIBUTING.md)
+
 ## [0.5.0] - 2022-09-14
 
 ### Added
@@ -35,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Hook dependencies are now properly listed, which is checked by ESLint. This fixes `useTypedSearchParams` for dynamic routes.
 -   Prevent access to internal `useUpdatingRef` helper.
 
+[unreleased]: https://github.com/fenok/react-router-typesafe-routes/tree/dev
 [0.5.0]: https://github.com/fenok/react-router-typesafe-routes/tree/v0.5.0
 [0.4.3]: https://github.com/fenok/react-router-typesafe-routes/tree/v0.4.3
 [0.4.2]: https://github.com/fenok/react-router-typesafe-routes/tree/v0.4.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+## Branches
+
+-   `main` represents the latest published version. It can only be updated automatically.
+-   `dev` represents a stable version used for development. At some point, `dev` is published and merged into `main`.
+
+## Pull Requests
+
+All code changes have to be done via pull requests to `dev` branch.
+
+Every pull request have to specify a deferred version bump via [yarn version](https://yarnpkg.com/cli/version) like this:
+
+```bash
+yarn version patch --deferred
+```
+
+It's also recommended to specify the changes in [CHANGELOG.md](./CHANGELOG.md). If needed, create an entry under `## [Unreleased]` header (right above the latest entry) and the corresponding link (`[unreleased]: https://github.com/fenok/react-router-typesafe-routes/tree/dev`). Upon release, it will be automatically replaced with an actual version and date.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 ## Branches
 
 -   `main` represents the latest published version. It can only be updated automatically.
--   `dev` represents a stable version used for development. At some point, `dev` is published and merged into `main`.
+-   `dev` represents the latest stable version used for development. At some point, `dev` is published and merged into `main`.
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ That is, the `$` property of every route contains original routes, specified as 
 
 It's important to understand that `DETAILS` and `PRODUCT.DETAILS` are separate routes, which may behave differently during parsing or building URLs. `DETAILS` doesn't know anything about `PRODUCT`, but `PRODUCT.DETAILS` does. `DETAILS` is a standalone route, but `PRODUCT.DETAILS` is a child of `PRODUCT`.
 
-> Child routes has to be in CONSTANT_CASE or PascalCase to prevent overlapping with other route fields.
+> Child routes have to be in CONSTANT_CASE or PascalCase to prevent overlapping with other route fields.
 
 These child routes correspond to child routes in react-router:
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The library is distributed as an ES module written in ES6.
 -   To make params merging possible, state has to be an object, and hash has to be one of the predefined strings (or any string).
 -   Since react-router only considers path on routes matching, search parameters, state fields, and hash are considered optional upon URL or state building.
 -   Hash is always considered optional upon URL parsing.
+-   To prevent overlapping with route API, child routes have to start with an uppercase letter.
+-   To emphasize that routes relativity is governed by the library, leading slashes in path templates are forbidden. Trailing slashes are also forbidden due to being purely cosmetic.
 
 ## How is it different from existing solutions?
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "native/"
     ],
     "engines": {
-        "node": "^16.14.2"
+        "node": ">=14"
     },
     "scripts": {
         "format": "prettier --write --ignore-unknown .",


### PR DESCRIPTION
Node version is currently locked to `16`, which makes using newer versions inconvenient.