### PR TITLE
Fix path generation when the first segment is optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+-   Fix path generation when the first segment is optional. Previously, `route(":optional?/:required").buildPath({ required: "req" })` would be `"//req"`.
+
 ## [1.2.0] - 2023-04-22
 
 ### Added
@@ -106,6 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Hook dependencies are now properly listed, which is checked by ESLint. This fixes `useTypedSearchParams` for dynamic routes.
 -   Prevent access to internal `useUpdatingRef` helper.
 
+[unreleased]: https://github.com/fenok/react-router-typesafe-routes/tree/dev
 [1.2.0]: https://github.com/fenok/react-router-typesafe-routes/tree/v1.2.0
 [1.1.0]: https://github.com/fenok/react-router-typesafe-routes/tree/v1.1.0
 [1.0.0]: https://github.com/fenok/react-router-typesafe-routes/tree/v1.0.0

--- a/src/common/createRoute/createRoute.ts
+++ b/src/common/createRoute/createRoute.ts
@@ -332,7 +332,9 @@ function getRoute<
     }
 
     function buildRelativePathname(params: InParams<TPath, TPathTypes>) {
-        return creatorOptions.generatePath(relativePath, getPlainParams(params));
+        const rawBuiltPath = creatorOptions.generatePath(relativePath, getPlainParams(params));
+
+        return rawBuiltPath.startsWith("/") ? rawBuiltPath.substring(1) : rawBuiltPath;
     }
 
     function buildSearch(params: InSearchParams<TSearchTypes>) {

--- a/src/dom/route.test.ts
+++ b/src/dom/route.test.ts
@@ -1589,7 +1589,7 @@ it("allows to mix types with deprecated ones", () => {
     expect(TEST_ROUTE.getTypedSearchParams(createSearchParams({ a: "1", b: "1" }))).toEqual({ a: 1, b: 1 });
 });
 
-it("generates correct paths if first segment is optional", () => {
+it("generates correct paths when the first segment is optional", () => {
     const TEST_ROUTE = route(":optional?/:required");
 
     expect(TEST_ROUTE.buildPath({ required: "req" })).toEqual("/req");

--- a/src/dom/route.test.ts
+++ b/src/dom/route.test.ts
@@ -1588,3 +1588,13 @@ it("allows to mix types with deprecated ones", () => {
     expect(TEST_ROUTE.getPlainSearchParams({ a: 1, b: 1 })).toEqual({ a: "1", b: "1" });
     expect(TEST_ROUTE.getTypedSearchParams(createSearchParams({ a: "1", b: "1" }))).toEqual({ a: 1, b: 1 });
 });
+
+it("generates correct paths if first segment is optional", () => {
+    const TEST_ROUTE = route(":optional?/:required");
+
+    expect(TEST_ROUTE.buildPath({ required: "req" })).toEqual("/req");
+    expect(TEST_ROUTE.buildPath({ optional: "opt", required: "req" })).toEqual("/opt/req");
+
+    expect(TEST_ROUTE.buildRelativePath({ required: "req" })).toEqual("req");
+    expect(TEST_ROUTE.buildRelativePath({ optional: "opt", required: "req" })).toEqual("opt/req");
+});


### PR DESCRIPTION
When the first segment is optional and not provided, the slash before the required segment is not omitted, which is unexpected for the library code, which adds its own slash.

So `route(":optional?/:required").buildPath({ required: "req" })` is `"//req"`, for example.