### PR TITLE
Forbid to pass any params for routes without them

### DIFF
--- a/.yarn/versions/9efd2e4c.yml
+++ b/.yarn/versions/9efd2e4c.yml
@@ -1,0 +1,2 @@
+releases:
+  react-router-typesafe-routes: patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+-   For routes without pathname/search params, non-empty objects are no longer accepted as these params.
+
 ## [1.2.1] - 2023-06-20
 
 ### Fixed
@@ -112,6 +118,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Hook dependencies are now properly listed, which is checked by ESLint. This fixes `useTypedSearchParams` for dynamic routes.
 -   Prevent access to internal `useUpdatingRef` helper.
 
+[unreleased]: https://github.com/fenok/react-router-typesafe-routes/tree/dev
 [1.2.1]: https://github.com/fenok/react-router-typesafe-routes/tree/v1.2.1
 [1.2.0]: https://github.com/fenok/react-router-typesafe-routes/tree/v1.2.0
 [1.1.0]: https://github.com/fenok/react-router-typesafe-routes/tree/v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   For routes without pathname/search params, non-empty objects are no longer accepted as these params.
+-   For routes without pathname/search/state params, non-empty objects are no longer accepted as these params.
 
 ## [1.2.1] - 2023-06-20
 

--- a/src/common/createRoute/createRoute.ts
+++ b/src/common/createRoute/createRoute.ts
@@ -89,19 +89,23 @@ interface Route<TPath extends string, TPathTypes, TSearchTypes, THash extends st
     ) => string;
 }
 
-type InParams<TPath extends string, TPathTypes> = Readable<
-    PartialByKey<
-        PickWithFallback<
-            RawParams<TPathTypes, "in">,
-            PathParam<SanitizedPath<PathWithoutIntermediateStars<TPath>>>,
-            string
-        >,
-        EnsureExtends<
-            PathParam<SanitizedPath<PathWithoutIntermediateStars<TPath>>, "optional", "in">,
-            PathParam<SanitizedPath<PathWithoutIntermediateStars<TPath>>>
-        >
-    >
->;
+type InParams<TPath extends string, TPathTypes> = [
+    PathParam<SanitizedPath<PathWithoutIntermediateStars<TPath>>>
+] extends [never]
+    ? Record<string, never>
+    : Readable<
+          PartialByKey<
+              PickWithFallback<
+                  RawParams<TPathTypes, "in">,
+                  PathParam<SanitizedPath<PathWithoutIntermediateStars<TPath>>>,
+                  string
+              >,
+              EnsureExtends<
+                  PathParam<SanitizedPath<PathWithoutIntermediateStars<TPath>>, "optional", "in">,
+                  PathParam<SanitizedPath<PathWithoutIntermediateStars<TPath>>>
+              >
+          >
+      >;
 
 type EnsureExtends<TFirst, TSecond> = TFirst extends TSecond ? TFirst : never;
 
@@ -115,7 +119,9 @@ type OutParamsByKey<TKey extends string, TOptionalKey extends string, TPathTypes
         EnsureExtends<Exclude<TOptionalKey, keyof TPathTypes>, Exclude<TKey, keyof TPathTypes>>
     >;
 
-type InSearchParams<TSearchTypes> = Readable<Partial<RawSearchParams<TSearchTypes, "in">>>;
+type InSearchParams<TSearchTypes> = [keyof TSearchTypes] extends [never]
+    ? Record<string, never>
+    : Readable<Partial<RawSearchParams<TSearchTypes, "in">>>;
 
 type OutSearchParams<TSearchTypes> = Readable<RawSearchParams<TSearchTypes, "out">>;
 

--- a/src/common/createRoute/createRoute.ts
+++ b/src/common/createRoute/createRoute.ts
@@ -125,7 +125,9 @@ type InSearchParams<TSearchTypes> = [keyof TSearchTypes] extends [never]
 
 type OutSearchParams<TSearchTypes> = Readable<RawSearchParams<TSearchTypes, "out">>;
 
-type InStateParams<TStateTypes> = Readable<Partial<RawStateParams<TStateTypes, "in">>>;
+type InStateParams<TStateTypes> = [keyof TStateTypes] extends [never]
+    ? Record<string, never>
+    : Readable<Partial<RawStateParams<TStateTypes, "in">>>;
 
 type OutStateParams<TStateTypes> = Readable<RawStateParams<TStateTypes, "out">>;
 

--- a/src/dom/route.deprecated.test.ts
+++ b/src/dom/route.deprecated.test.ts
@@ -329,7 +329,7 @@ it("allows implicit star path param", () => {
 
     expect(TEST_ROUTE.buildPath({})).toEqual("/test");
     expect(TEST_ROUTE.CHILD.buildPath({ "*": "star/param" })).toEqual("/test/child/star/param");
-    expect(TEST_ROUTE.CHILD.GRANDCHILD.buildPath({ "*": "star/param" })).toEqual("/test/child/grand");
+    expect(TEST_ROUTE.CHILD.GRANDCHILD.buildPath({})).toEqual("/test/child/grand");
 });
 
 it("allows implicit optional star path param", () => {
@@ -343,7 +343,7 @@ it("allows implicit optional star path param", () => {
 
     expect(TEST_ROUTE.buildPath({})).toEqual("/test");
     expect(TEST_ROUTE.CHILD.buildPath({ "*": "star/param" })).toEqual("/test/child/star/param");
-    expect(TEST_ROUTE.CHILD.GRANDCHILD.buildPath({ "*": "star/param" })).toEqual("/test/child/grand");
+    expect(TEST_ROUTE.CHILD.GRANDCHILD.buildPath({})).toEqual("/test/child/grand");
 });
 
 it("allows explicit star path param", () => {
@@ -397,9 +397,9 @@ it("allows star path param in the middle of combined path", () => {
     assert<IsExact<Parameters<typeof TEST_ROUTE.CHILD.buildPath>[0], { "*"?: string }>>(true);
     assert<IsExact<Parameters<typeof TEST_ROUTE.CHILD.GRANDCHILD.buildPath>[0], Record<never, never>>>(true);
 
-    expect(TEST_ROUTE.buildPath({ "*": "foo" })).toEqual("/test");
+    expect(TEST_ROUTE.buildPath({})).toEqual("/test");
     expect(TEST_ROUTE.CHILD.buildPath({ "*": "foo" })).toEqual("/test/child/foo");
-    expect(TEST_ROUTE.CHILD.GRANDCHILD.buildPath({ "*": "foo" })).toEqual("/test/child/grand");
+    expect(TEST_ROUTE.CHILD.GRANDCHILD.buildPath({})).toEqual("/test/child/grand");
 });
 
 it("allows search params", () => {

--- a/src/dom/route.test.ts
+++ b/src/dom/route.test.ts
@@ -1598,3 +1598,25 @@ it("generates correct paths when the first segment is optional", () => {
     expect(TEST_ROUTE.buildRelativePath({ required: "req" })).toEqual("req");
     expect(TEST_ROUTE.buildRelativePath({ optional: "opt", required: "req" })).toEqual("opt/req");
 });
+
+it("disallows pathname input params when there are no pathname params", () => {
+    const TEST_ROUTE = route("test");
+    const TEST_ROUTE_WITH_EMPTY_PARAMS = route("test", { params: {} });
+
+    // @ts-expect-error There are no pathname params
+    TEST_ROUTE.buildPath({ id: 1 });
+
+    // @ts-expect-error There are no pathname params
+    TEST_ROUTE_WITH_EMPTY_PARAMS.buildPath({ id: 1 });
+});
+
+it("disallows search input params when there are no search params", () => {
+    const TEST_ROUTE = route("test");
+    const TEST_ROUTE_WITH_EMPTY_PARAMS = route("test", { searchParams: {} });
+
+    // @ts-expect-error There are no search params
+    TEST_ROUTE.buildPath({}, { id: 1 });
+
+    // @ts-expect-error There are no search params
+    TEST_ROUTE_WITH_EMPTY_PARAMS.buildPath({}, { id: 1 });
+});

--- a/src/dom/route.test.ts
+++ b/src/dom/route.test.ts
@@ -338,7 +338,7 @@ it("allows implicit star path param", () => {
 
     expect(TEST_ROUTE.buildPath({})).toEqual("/test");
     expect(TEST_ROUTE.CHILD.buildPath({ "*": "star/param" })).toEqual("/test/child/star/param");
-    expect(TEST_ROUTE.CHILD.GRANDCHILD.buildPath({ "*": "star/param" })).toEqual("/test/child/grand");
+    expect(TEST_ROUTE.CHILD.GRANDCHILD.buildPath({})).toEqual("/test/child/grand");
 });
 
 it("allows implicit optional star path param", () => {
@@ -352,7 +352,7 @@ it("allows implicit optional star path param", () => {
 
     expect(TEST_ROUTE.buildPath({})).toEqual("/test");
     expect(TEST_ROUTE.CHILD.buildPath({ "*": "star/param" })).toEqual("/test/child/star/param");
-    expect(TEST_ROUTE.CHILD.GRANDCHILD.buildPath({ "*": "star/param" })).toEqual("/test/child/grand");
+    expect(TEST_ROUTE.CHILD.GRANDCHILD.buildPath({})).toEqual("/test/child/grand");
 });
 
 it("allows explicit star path param", () => {
@@ -406,9 +406,9 @@ it("allows star path param in the middle of combined path", () => {
     assert<IsExact<Parameters<typeof TEST_ROUTE.CHILD.buildPath>[0], { "*"?: string }>>(true);
     assert<IsExact<Parameters<typeof TEST_ROUTE.CHILD.GRANDCHILD.buildPath>[0], Record<never, never>>>(true);
 
-    expect(TEST_ROUTE.buildPath({ "*": "foo" })).toEqual("/test");
+    expect(TEST_ROUTE.buildPath({})).toEqual("/test");
     expect(TEST_ROUTE.CHILD.buildPath({ "*": "foo" })).toEqual("/test/child/foo");
-    expect(TEST_ROUTE.CHILD.GRANDCHILD.buildPath({ "*": "foo" })).toEqual("/test/child/grand");
+    expect(TEST_ROUTE.CHILD.GRANDCHILD.buildPath({})).toEqual("/test/child/grand");
 });
 
 it("allows search params", () => {

--- a/src/dom/route.test.ts
+++ b/src/dom/route.test.ts
@@ -1620,3 +1620,14 @@ it("disallows search input params when there are no search params", () => {
     // @ts-expect-error There are no search params
     TEST_ROUTE_WITH_EMPTY_PARAMS.buildPath({}, { id: 1 });
 });
+
+it("disallows state input params when there are no state params", () => {
+    const TEST_ROUTE = route("test");
+    const TEST_ROUTE_WITH_EMPTY_PARAMS = route("test", { state: {} });
+
+    // @ts-expect-error There are no state params
+    TEST_ROUTE.buildState({ id: 1 });
+
+    // @ts-expect-error There are no state params
+    TEST_ROUTE_WITH_EMPTY_PARAMS.buildState({ id: 1 });
+});


### PR DESCRIPTION
Closes #49 

Might be revisited in the future because it breaks a potential use case where we can define an object with params and try to pass it to several routes, some of which might be without params. Ideally, we would want an [excess property check](https://www.typescriptlang.org/docs/handbook/2/objects.html#excess-property-checks) here (that forbids every property), but it doesn't seem possible.

For now, the behavior introduced by this PR seems more valuable.